### PR TITLE
SCRUM-8760: allow failed wheel builds

### DIFF
--- a/mkwheelhouse.py
+++ b/mkwheelhouse.py
@@ -133,7 +133,10 @@ def build_wheels(packages, index_url, requirements, exclusions):
         args += ['--requirement', requirement]
 
     args += packages
-    subprocess.check_call(args)
+    try:
+        subprocess.check_call(args)
+    except subprocess.CalledProcessError:
+        print('Wheel build for one or more packages failed.')
 
     for exclusion in exclusions:
         matches = glob.glob(os.path.join(temp_dir, exclusion))


### PR DESCRIPTION
This won't cause failed wheels to be pushed to s3. Let pip install fallback to non-wheel install.